### PR TITLE
Add NetZone autonomous blue and red OpModes

### DIFF
--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/NetZoneAutonomousBase.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/NetZoneAutonomousBase.java
@@ -1,0 +1,83 @@
+package org.firstinspires.ftc.teamcode;
+
+import com.qualcomm.robotcore.eventloop.opmode.LinearOpMode;
+import com.qualcomm.robotcore.util.ElapsedTime;
+import java.util.ArrayList;
+import java.util.List;
+
+public abstract class NetZoneAutonomousBase extends LinearOpMode {
+    protected enum Alliance {
+        BLUE,
+        RED
+    }
+
+    private final Alliance alliance;
+
+    protected NetZoneAutonomousBase(Alliance alliance) {
+        this.alliance = alliance;
+    }
+
+    @Override
+    public void runOpMode() {
+        telemetry.addLine("NetZone autonomous ready.");
+        telemetry.addData("Alliance", alliance);
+        telemetry.update();
+
+        waitForStart();
+
+        if (isStopRequested()) {
+            return;
+        }
+
+        runAutonomousSequence();
+
+        telemetry.addLine("NetZone autonomous complete.");
+        telemetry.update();
+        sleep(250);
+    }
+
+    private void runAutonomousSequence() {
+        List<Step> steps = buildSteps();
+        ElapsedTime stepTimer = new ElapsedTime();
+
+        for (Step step : steps) {
+            if (!opModeIsActive()) {
+                return;
+            }
+
+            telemetry.addData("Step", step.description);
+            telemetry.addData("Target", "%.1f sec", step.durationSeconds);
+            telemetry.update();
+
+            stepTimer.reset();
+            while (opModeIsActive() && stepTimer.seconds() < step.durationSeconds) {
+                telemetry.addData("Elapsed", "%.1f sec", stepTimer.seconds());
+                telemetry.update();
+                idle();
+            }
+        }
+    }
+
+    private List<Step> buildSteps() {
+        List<Step> steps = new ArrayList<>();
+        String strafeDirection = alliance == Alliance.BLUE ? "strafe left" : "strafe right";
+
+        steps.add(new Step("Leave start tile", 1.0));
+        steps.add(new Step("Drive toward NetZone", 1.5));
+        steps.add(new Step("Align with target (" + strafeDirection + ")", 1.0));
+        steps.add(new Step("Score preload", 1.0));
+        steps.add(new Step("Park in NetZone", 1.0));
+
+        return steps;
+    }
+
+    protected static class Step {
+        private final String description;
+        private final double durationSeconds;
+
+        private Step(String description, double durationSeconds) {
+            this.description = description;
+            this.durationSeconds = durationSeconds;
+        }
+    }
+}

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/NetZoneAutonomousBlue.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/NetZoneAutonomousBlue.java
@@ -1,0 +1,10 @@
+package org.firstinspires.ftc.teamcode;
+
+import com.qualcomm.robotcore.eventloop.opmode.Autonomous;
+
+@Autonomous(name = "NetZone Auto Blue", group = "NetZone")
+public class NetZoneAutonomousBlue extends NetZoneAutonomousBase {
+    public NetZoneAutonomousBlue() {
+        super(Alliance.BLUE);
+    }
+}

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/NetZoneAutonomousRed.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/NetZoneAutonomousRed.java
@@ -1,0 +1,10 @@
+package org.firstinspires.ftc.teamcode;
+
+import com.qualcomm.robotcore.eventloop.opmode.Autonomous;
+
+@Autonomous(name = "NetZone Auto Red", group = "NetZone")
+public class NetZoneAutonomousRed extends NetZoneAutonomousBase {
+    public NetZoneAutonomousRed() {
+        super(Alliance.RED);
+    }
+}


### PR DESCRIPTION
### Motivation
- Provide an alliance-aware NetZone autonomous routine with both Blue and Red variants to avoid duplicating logic and make step flow consistent across alliances.
- Surface simple telemetry and timing for each step so drivers can observe routine progress during autonomous.

### Description
- Add `NetZoneAutonomousBase` in `TeamCode/src/main/java/org/firstinspires/ftc/teamcode/` which extends `LinearOpMode`, defines an `Alliance` enum, and implements a timed step sequence with telemetry.
- Implement `buildSteps()` in the base to select a strafe direction based on alliance and produce a list of `Step` entries used by `runAutonomousSequence()` for timed execution and telemetry updates.
- Add `NetZoneAutonomousBlue` and `NetZoneAutonomousRed` OpModes annotated with `@Autonomous` that subclass the base and pass `Alliance.BLUE` and `Alliance.RED` respectively.
- Introduce an internal `Step` class to represent step description and duration used by the sequence runner.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696dbcd001c4832d84fa981a0bab6b3f)